### PR TITLE
Completed implementation of view playlist use case

### DIFF
--- a/src/data_access/ViewPlaylistDataAccessObject.java
+++ b/src/data_access/ViewPlaylistDataAccessObject.java
@@ -1,0 +1,34 @@
+package data_access;
+
+import entity.Playlist;
+import entity.Song;
+import use_case.view_playlist.ViewPlaylistDataAccessInterface;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ViewPlaylistDataAccessObject implements ViewPlaylistDataAccessInterface {
+
+    @Override
+    public List<String> getPlaylistData(Playlist playlist) {
+
+        List<String> playlistData = new ArrayList<>();
+
+        if (playlist != null) {
+            playlistData.add("Playlist Name: " + playlist.getName());
+
+            List<Song> songs = playlist.getList();
+            for (Song song : songs) {
+                // Add each song as a separate line
+                String songInfo = song.getName() + " by " + song.getAuthor();
+                playlistData.add(songInfo);
+            }
+        } else {
+            playlistData.add("Invalid playlist");
+
+        }
+
+        return playlistData;
+    }
+
+}

--- a/src/data_access/ViewPlaylistDataAccessObject.java
+++ b/src/data_access/ViewPlaylistDataAccessObject.java
@@ -3,7 +3,6 @@ package data_access;
 import entity.CompletePlaylist;
 import entity.CompleteSong;
 import entity.Playlist;
-import entity.Song;
 import use_case.view_playlist.ViewPlaylistDataAccessInterface;
 
 import java.util.ArrayList;

--- a/src/data_access/ViewPlaylistDataAccessObject.java
+++ b/src/data_access/ViewPlaylistDataAccessObject.java
@@ -1,5 +1,7 @@
 package data_access;
 
+import entity.CompletePlaylist;
+import entity.CompleteSong;
 import entity.Playlist;
 import entity.Song;
 import use_case.view_playlist.ViewPlaylistDataAccessInterface;
@@ -14,13 +16,29 @@ public class ViewPlaylistDataAccessObject implements ViewPlaylistDataAccessInter
 
         List<String> playlistData = new ArrayList<>();
 
-        if (playlist != null) {
-            playlistData.add("Playlist Name: " + playlist.getName());
+        if (playlist != null && playlist instanceof CompletePlaylist) {
 
-            List<Song> songs = playlist.getList();
-            for (Song song : songs) {
-                // Add each song as a separate line
-                String songInfo = song.getName() + " by " + song.getAuthor();
+            CompletePlaylist completePlaylist = (CompletePlaylist) playlist;
+
+            playlistData.add("Playlist Name: " + completePlaylist.getName());
+
+            List<CompleteSong> songs = completePlaylist.getCompleteSongs();
+
+            for (CompleteSong song : songs) {
+
+                // Extract complete song information
+                String name = song.getName();
+                String author = song.getAuthor();
+                String date = song.getDate();
+                String youtubeID = song.getYoutubeId();
+                String spotifyID = song.getSpotifyId();
+                String youtubeTitle = song.getYoutubeTitle();
+                String youtubeChannel = song.getYoutubeChannel();
+
+                String songInfo = name + " by " + author + " released " + date + ", YoutubeID: " +
+                        youtubeID + ", SpotifyID: " + spotifyID + ", Youtube Title: " +
+                        youtubeTitle + ", Youtube Channel Name: " + youtubeChannel;
+
                 playlistData.add(songInfo);
             }
         } else {

--- a/src/entity/CompleteSong.java
+++ b/src/entity/CompleteSong.java
@@ -32,6 +32,14 @@ public class CompleteSong extends Song {
         return this.duration;
     }
 
+    public String getYoutubeTitle() {
+        return this.youtubeTitle;
+    }
+
+    public  String getYoutubeChannel() {
+        return this.youtubeChannel;
+    }
+
     @Override
     public JSONObject convertToJSON() {
         JSONObject jsonObject = new JSONObject();

--- a/src/interface_adapter/PutPlaylistState.java
+++ b/src/interface_adapter/PutPlaylistState.java
@@ -11,6 +11,7 @@ public class PutPlaylistState {
     private JSONObject saveFileText;
     private String playlistName;
     private String successUrl;
+    private String outputTextView;
 
     public void setError(String error) {
         this.error = error;
@@ -53,6 +54,15 @@ public class PutPlaylistState {
 
     public JSONObject getSaveFileText() {
         return saveFileText;
+    }
+
+    // the following was added for viewplaylist use case
+    public void setOutputTextView(String outputTextView) {
+        this.outputTextView = outputTextView;
+    }
+
+    public String getOutputTextView() {
+        return outputTextView;
     }
 
 }

--- a/src/interface_adapter/view_playlist/ViewPlaylistController.java
+++ b/src/interface_adapter/view_playlist/ViewPlaylistController.java
@@ -1,4 +1,27 @@
 package interface_adapter.view_playlist;
 
+import entity.Playlist;
+import use_case.view_playlist.ViewPlaylistInputBoundary;
+import use_case.view_playlist.ViewPlaylistInputData;
+
 public class ViewPlaylistController {
+
+    final ViewPlaylistInputBoundary viewPlaylistUseCaseInteractor;
+
+    public ViewPlaylistController(ViewPlaylistInputBoundary viewPlaylistUseCaseInteractor) {
+
+        this.viewPlaylistUseCaseInteractor = viewPlaylistUseCaseInteractor;
+
+    }
+
+    public void execute(Playlist playlist) {
+
+        ViewPlaylistInputData viewPlaylistInputData = new ViewPlaylistInputData(playlist);
+
+        //invoke the use case interactor
+
+        viewPlaylistUseCaseInteractor.execute(viewPlaylistInputData);
+
+    }
+
 }

--- a/src/interface_adapter/view_playlist/ViewPlaylistPresenter.java
+++ b/src/interface_adapter/view_playlist/ViewPlaylistPresenter.java
@@ -1,6 +1,39 @@
 package interface_adapter.view_playlist;
 
 import use_case.view_playlist.ViewPlaylistOutputBoundary;
+import use_case.view_playlist.ViewPlaylistOutputData;
+import interface_adapter.*;
+
+import java.util.List;
 
 public class ViewPlaylistPresenter implements ViewPlaylistOutputBoundary {
+
+    private final PutPlaylistViewModel viewPlaylistViewModel;
+
+    public ViewPlaylistPresenter(PutPlaylistViewModel viewPlaylistViewModel) {
+
+        this.viewPlaylistViewModel = viewPlaylistViewModel;
+
+    }
+
+    @Override
+    public void prepareSuccessView(ViewPlaylistOutputData viewPlaylistOutputData) {
+
+        PutPlaylistState viewPlaylistState = viewPlaylistViewModel.getState();
+        viewPlaylistState.setError(null);
+        List<String> playlistText = viewPlaylistOutputData.getPlaylistText();
+        viewPlaylistState.setOutputTextView(String.join("\n", playlistText));
+        this.viewPlaylistViewModel.setState(viewPlaylistState);
+        this.viewPlaylistViewModel.firePropertyChanged();
+
+    }
+
+    @Override
+    public void prepareFailView(String error) {
+        PutPlaylistState viewPlaylistState = viewPlaylistViewModel.getState();
+        viewPlaylistState.setError(error);
+        this.viewPlaylistViewModel.firePropertyChanged();
+
+    }
+
 }

--- a/src/test/TestViewPlaylist.java
+++ b/src/test/TestViewPlaylist.java
@@ -6,6 +6,8 @@ import entity.CompleteSong;
 import entity.Playlist;
 import entity.YoutubePlaylist;
 import entity.SpotifyPlaylist;
+import interface_adapter.GetPlaylistViewModel;
+import interface_adapter.PutPlaylistState;
 import interface_adapter.PutPlaylistViewModel;
 import interface_adapter.view_playlist.ViewPlaylistController;
 import interface_adapter.view_playlist.ViewPlaylistPresenter;
@@ -15,15 +17,22 @@ import use_case.view_playlist.ViewPlaylistInputData;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 public class TestViewPlaylist {
 
     private ViewPlaylistController controller;
 
     private Playlist completePlaylist;
 
+    private PutPlaylistViewModel viewPlaylistViewModel;
+
     @Before
     public void setup() {
-        PutPlaylistViewModel viewPlaylistViewModel = new PutPlaylistViewModel();
+        viewPlaylistViewModel = new PutPlaylistViewModel();
+
         ViewPlaylistDataAccessObject dataAccessObject = new ViewPlaylistDataAccessObject();
         ViewPlaylistOutputBoundary outputBoundary = new ViewPlaylistPresenter(viewPlaylistViewModel);
         TempFileWriterDataAccessObject fileWriter = new TempFileWriterDataAccessObject("temp.json");
@@ -40,6 +49,36 @@ public class TestViewPlaylist {
     public void testPresenterBehavior() {
         if (completePlaylist != null && completePlaylist instanceof CompletePlaylist) {
             controller.execute(completePlaylist);
+        }
+        else {
+            System.out.println("This was an empty playlist or not a complete playlist");
+        }
+
+    }
+
+    // test that the information is being stored to the state correctly
+    @Test
+    public void testSongOutputCorrectness() {
+        if (completePlaylist != null && completePlaylist instanceof CompletePlaylist) {
+            controller.execute(completePlaylist);
+
+            //Testing the state
+            PutPlaylistState state = viewPlaylistViewModel.getState();
+            assertNotNull(state);
+
+            String outputTextView = state.getOutputTextView();
+            assertNotNull(outputTextView);
+
+            System.out.println(outputTextView);
+
+            // Split the outputTextView into lines
+            String[] lines = outputTextView.split("\n");
+
+            String firstSongInfo = "Rolling in the Deep by Adele released 2011-01-24, " +
+                    "YoutubeID: rYEDA3JcQqw, SpotifyID: 1c8gk2PeTE04A1pIDH9YMk, " +
+                    "Youtube Title: Adele - Rolling in the Deep (Official Music Video), " +
+                    "Youtube Channel Name: AdeleVEVO";
+            assertEquals(firstSongInfo, lines[1]);
         }
 
         else {

--- a/src/test/TestViewPlaylist.java
+++ b/src/test/TestViewPlaylist.java
@@ -1,0 +1,52 @@
+
+import data_access.ViewPlaylistDataAccessObject;
+import data_access.TempFileWriterDataAccessObject;
+import entity.CompletePlaylist;
+import entity.CompleteSong;
+import entity.Playlist;
+import entity.YoutubePlaylist;
+import entity.SpotifyPlaylist;
+import interface_adapter.PutPlaylistViewModel;
+import interface_adapter.view_playlist.ViewPlaylistController;
+import interface_adapter.view_playlist.ViewPlaylistPresenter;
+import use_case.view_playlist.ViewPlaylistInteractor;
+import use_case.view_playlist.ViewPlaylistOutputBoundary;
+import use_case.view_playlist.ViewPlaylistInputData;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+public class TestViewPlaylist {
+
+    private ViewPlaylistController controller;
+
+    private Playlist completePlaylist;
+
+    @Before
+    public void setup() {
+        PutPlaylistViewModel viewPlaylistViewModel = new PutPlaylistViewModel();
+        ViewPlaylistDataAccessObject dataAccessObject = new ViewPlaylistDataAccessObject();
+        ViewPlaylistOutputBoundary outputBoundary = new ViewPlaylistPresenter(viewPlaylistViewModel);
+        TempFileWriterDataAccessObject fileWriter = new TempFileWriterDataAccessObject("temp.json");
+
+        // Read playlists from JSON file
+        completePlaylist = fileWriter.readPlaylistJSON();
+
+        ViewPlaylistInteractor interactor = new ViewPlaylistInteractor(dataAccessObject, outputBoundary);
+
+        controller = new ViewPlaylistController(interactor);
+    }
+
+    @Test
+    public void testPresenterBehavior() {
+        if (completePlaylist != null && completePlaylist instanceof CompletePlaylist) {
+            controller.execute(completePlaylist);
+        }
+
+        else {
+            System.out.println("This was an empty playlist or not a complete playlist");
+        }
+
+    }
+
+}
+

--- a/src/use_case/view_playlist/ViewPlaylistDataAccessInterface.java
+++ b/src/use_case/view_playlist/ViewPlaylistDataAccessInterface.java
@@ -1,4 +1,14 @@
 package use_case.view_playlist;
 
+import entity.Playlist;
+import entity.Song;
+
+import java.util.List;
+
 public interface ViewPlaylistDataAccessInterface {
+
+    //Gets the playlist data and returns a list of strings, each string including song information
+    // to be displayed
+    List<String> getPlaylistData(Playlist playlist);
+
 }

--- a/src/use_case/view_playlist/ViewPlaylistInputBoundary.java
+++ b/src/use_case/view_playlist/ViewPlaylistInputBoundary.java
@@ -1,4 +1,8 @@
 package use_case.view_playlist;
 
 public interface ViewPlaylistInputBoundary {
+
+    // Execute function that takes in the input data and calls the interactor
+
+    void execute(ViewPlaylistInputData inputData);
 }

--- a/src/use_case/view_playlist/ViewPlaylistInputData.java
+++ b/src/use_case/view_playlist/ViewPlaylistInputData.java
@@ -1,4 +1,15 @@
 package use_case.view_playlist;
 
+import entity.Playlist;
+
 public class ViewPlaylistInputData {
+    private final Playlist playlist;
+
+    public ViewPlaylistInputData(Playlist playlist) {
+        this.playlist = playlist;
+    }
+
+    public Playlist getPlaylist() {
+        return playlist;
+    }
 }

--- a/src/use_case/view_playlist/ViewPlaylistInteractor.java
+++ b/src/use_case/view_playlist/ViewPlaylistInteractor.java
@@ -1,4 +1,45 @@
 package use_case.view_playlist;
+import entity.Playlist;
+
+import java.util.List;
 
 public class ViewPlaylistInteractor implements ViewPlaylistInputBoundary {
+    private final ViewPlaylistDataAccessInterface viewPlaylistDataAccess;
+
+    private final ViewPlaylistOutputBoundary viewPlaylistPresenter;
+
+    public ViewPlaylistInteractor(ViewPlaylistDataAccessInterface viewPlaylistDataAccess,
+                                  ViewPlaylistOutputBoundary viewPlaylistPresenter) {
+        this.viewPlaylistDataAccess = viewPlaylistDataAccess;
+        this.viewPlaylistPresenter = viewPlaylistPresenter;
+
+    }
+
+    @Override
+    public void execute(ViewPlaylistInputData viewPlaylistInputData) {
+        try {
+            if (viewPlaylistInputData.getPlaylist() != null) {
+
+                // Get the playlist from the input data
+                Playlist playlist = viewPlaylistInputData.getPlaylist();
+                // Directly use getPlaylistData method to get the formatted playlist data
+                List<String> playlistText = viewPlaylistDataAccess.getPlaylistData(playlist);
+
+                // Create output data object to invoke into presenter success view
+                ViewPlaylistOutputData viewPlaylistOutputData = new ViewPlaylistOutputData(playlistText);
+
+                viewPlaylistPresenter.prepareSuccessView(viewPlaylistOutputData);
+
+            } else {
+                // Invoke presenter with fail view and error message
+                viewPlaylistPresenter.prepareFailView("Please input a valid playlist");
+            }
+        } catch (Exception e) {
+            // Invoke presenter with fail view and error message
+            viewPlaylistPresenter.prepareFailView("Failed to display playlist");
+
+        }
+
+    }
+
 }

--- a/src/use_case/view_playlist/ViewPlaylistOutputBoundary.java
+++ b/src/use_case/view_playlist/ViewPlaylistOutputBoundary.java
@@ -1,4 +1,8 @@
 package use_case.view_playlist;
 
 public interface ViewPlaylistOutputBoundary {
+
+    void prepareSuccessView(ViewPlaylistOutputData viewPlaylistOutputData);
+
+    void prepareFailView(String error);
 }

--- a/src/use_case/view_playlist/ViewPlaylistOutputData.java
+++ b/src/use_case/view_playlist/ViewPlaylistOutputData.java
@@ -1,4 +1,16 @@
 package use_case.view_playlist;
 
+import java.util.List;
+
 public class ViewPlaylistOutputData {
+
+    private final List<String> playlistText;
+
+    public ViewPlaylistOutputData(List<String> playlistText) {
+        this.playlistText = playlistText;
+    }
+
+    public List<String> getPlaylistText() {
+        return playlistText;
+    }
 }


### PR DESCRIPTION
The view playlist use case is now completed and should display the correct information on the view page. With its current implementation, the output text is a string with each song separated by /n to indicate a new line. For readability, I will continue to figure out how to display song information line by line. An option is to loop through the string for each song and then update the view model each time, but I am worried about the efficiency of such approach. Please review these changes and let me know how I can make this viewable in a more readable format (i.e. line by line information displayed). 