### PR TITLE
token safety use case

### DIFF
--- a/src/app/GetPlaylistUseCaseFactory.java
+++ b/src/app/GetPlaylistUseCaseFactory.java
@@ -1,15 +1,15 @@
 package app;
 
 import data_access.*;
-import data_access.APIs.SpotifyAPIAdapter;
 import data_access.APIs.SpotifyAPIAdapterInterface;
-import data_access.APIs.YoutubeAPIAdapter;
 import data_access.APIs.YoutubeAPIAdapterInterface;
 import interface_adapter.*;
 import interface_adapter.load_playlist.LoadPlaylistController;
 import interface_adapter.load_playlist.LoadPlaylistPresenter;
 import interface_adapter.load_token.LoadTokenController;
 import interface_adapter.load_token.LoadTokenPresenter;
+import interface_adapter.save_token.SaveTokenController;
+import interface_adapter.save_token.SaveTokenPresenter;
 import interface_adapter.spotify_get.SpotifyGetController;
 import interface_adapter.spotify_get.SpotifyGetPresenter;
 import interface_adapter.youtube_get.YoutubeGetController;
@@ -22,6 +22,10 @@ import use_case.load_token.LoadTokenDataAccessInterface;
 import use_case.load_token.LoadTokenInputBoundary;
 import use_case.load_token.LoadTokenInteractor;
 import use_case.load_token.LoadTokenOutputBoundary;
+import use_case.save_token.SaveTokenDataAccessInterface;
+import use_case.save_token.SaveTokenInputBoundary;
+import use_case.save_token.SaveTokenInteractor;
+import use_case.save_token.SaveTokenOutputBoundary;
 import use_case.spotify_get.SpotifyGetDataAccessInterface;
 import use_case.spotify_get.SpotifyGetInputBoundary;
 import use_case.spotify_get.SpotifyGetInteractor;
@@ -48,7 +52,8 @@ public class GetPlaylistUseCaseFactory {
             LoadPlaylistController loadPlaylistController = createLoadPlaylistUseCase(viewManagerModel, getPlaylistViewModel, processPlaylistViewModel, putPlaylistViewModel);
             YoutubeGetController youtubeGetController = createYoutubeGetUseCase(viewManagerModel, getPlaylistViewModel, processPlaylistViewModel, fileWriter, youtubeAPI);
             SpotifyGetController spotifyGetController = createSpotifyGetUseCase(viewManagerModel, getPlaylistViewModel, processPlaylistViewModel, fileWriter, spotifyAPI);
-            return new InitialView(getPlaylistViewModel, youtubeGetController, spotifyGetController, loadPlaylistController, loadTokenController);
+            SaveTokenController saveTokenController = createSaveTokenUseCase(viewManagerModel, getPlaylistViewModel, youtubeAPI, spotifyAPI);
+            return new InitialView(getPlaylistViewModel, youtubeGetController, spotifyGetController, loadPlaylistController, loadTokenController, saveTokenController);
         } catch (IOException e) {
             JOptionPane.showMessageDialog(null, "could not load initial page");
         }
@@ -65,6 +70,17 @@ public class GetPlaylistUseCaseFactory {
         LoadTokenInputBoundary loadTokenInteractor = new LoadTokenInteractor(loadTokenDataAccessObject, loadTokenOutputBoundary, youtubeAPI, spotifyAPI);
 
         return new LoadTokenController(loadTokenInteractor);
+    }
+
+    private static SaveTokenController createSaveTokenUseCase(
+            ViewManagerModel viewManagerModel, GetPlaylistViewModel getPlaylistViewModel,
+            YoutubeAPIAdapterInterface youtubeAPI, SpotifyAPIAdapterInterface spotifyAPI) throws IOException {
+
+        SaveTokenOutputBoundary saveTokenOutputBoundary = new SaveTokenPresenter(viewManagerModel, getPlaylistViewModel);
+        SaveTokenDataAccessInterface saveTokenDataAccessObject = new SaveTokenDataAccessObject();
+        SaveTokenInputBoundary saveTokenInteractor = new SaveTokenInteractor(saveTokenDataAccessObject, saveTokenOutputBoundary, youtubeAPI, spotifyAPI);
+
+        return new SaveTokenController(saveTokenInteractor);
     }
 
 

--- a/src/app/GetPlaylistUseCaseFactory.java
+++ b/src/app/GetPlaylistUseCaseFactory.java
@@ -1,16 +1,15 @@
 package app;
 
+import data_access.*;
 import data_access.APIs.SpotifyAPIAdapter;
 import data_access.APIs.SpotifyAPIAdapterInterface;
 import data_access.APIs.YoutubeAPIAdapter;
 import data_access.APIs.YoutubeAPIAdapterInterface;
-import data_access.LoadPlaylistDataAccessObject;
-import data_access.SpotifyGetDataAccessObject;
-import data_access.TempFileWriterDataAccessObject;
-import data_access.YoutubeGetDataAccessObject;
 import interface_adapter.*;
 import interface_adapter.load_playlist.LoadPlaylistController;
 import interface_adapter.load_playlist.LoadPlaylistPresenter;
+import interface_adapter.load_token.LoadTokenController;
+import interface_adapter.load_token.LoadTokenPresenter;
 import interface_adapter.spotify_get.SpotifyGetController;
 import interface_adapter.spotify_get.SpotifyGetPresenter;
 import interface_adapter.youtube_get.YoutubeGetController;
@@ -19,6 +18,10 @@ import use_case.load_playlist.LoadPlaylistDataAccessInterface;
 import use_case.load_playlist.LoadPlaylistInputBoundary;
 import use_case.load_playlist.LoadPlaylistInteractor;
 import use_case.load_playlist.LoadPlaylistOutputBoundary;
+import use_case.load_token.LoadTokenDataAccessInterface;
+import use_case.load_token.LoadTokenInputBoundary;
+import use_case.load_token.LoadTokenInteractor;
+import use_case.load_token.LoadTokenOutputBoundary;
 import use_case.spotify_get.SpotifyGetDataAccessInterface;
 import use_case.spotify_get.SpotifyGetInputBoundary;
 import use_case.spotify_get.SpotifyGetInteractor;
@@ -36,21 +39,34 @@ public class GetPlaylistUseCaseFactory {
 
     private GetPlaylistUseCaseFactory() {}
 
-    public static InitialView create(ViewManagerModel viewManagerModel,
-                                     GetPlaylistViewModel getPlaylistViewModel,
-                                     ProcessPlaylistViewModel processPlaylistViewModel,
-                                     PutPlaylistViewModel putPlaylistViewModel,
+    public static InitialView create(SpotifyAPIAdapterInterface spotifyAPI, YoutubeAPIAdapterInterface youtubeAPI,
+                                     ViewManagerModel viewManagerModel, GetPlaylistViewModel getPlaylistViewModel,
+                                     ProcessPlaylistViewModel processPlaylistViewModel, PutPlaylistViewModel putPlaylistViewModel,
                                      TempFileWriterDataAccessObject fileWriter) {
         try {
+            LoadTokenController loadTokenController = createLoadTokenUseCase(viewManagerModel, getPlaylistViewModel, processPlaylistViewModel, putPlaylistViewModel, youtubeAPI, spotifyAPI);
             LoadPlaylistController loadPlaylistController = createLoadPlaylistUseCase(viewManagerModel, getPlaylistViewModel, processPlaylistViewModel, putPlaylistViewModel);
-            YoutubeGetController youtubeGetController = createYoutubeGetUseCase(viewManagerModel, getPlaylistViewModel, processPlaylistViewModel, fileWriter);
-            SpotifyGetController spotifyGetController = createSpotifyGetUseCase(viewManagerModel, getPlaylistViewModel, processPlaylistViewModel, fileWriter);
-            return new InitialView(getPlaylistViewModel, youtubeGetController, spotifyGetController, loadPlaylistController);
+            YoutubeGetController youtubeGetController = createYoutubeGetUseCase(viewManagerModel, getPlaylistViewModel, processPlaylistViewModel, fileWriter, youtubeAPI);
+            SpotifyGetController spotifyGetController = createSpotifyGetUseCase(viewManagerModel, getPlaylistViewModel, processPlaylistViewModel, fileWriter, spotifyAPI);
+            return new InitialView(getPlaylistViewModel, youtubeGetController, spotifyGetController, loadPlaylistController, loadTokenController);
         } catch (IOException e) {
             JOptionPane.showMessageDialog(null, "could not load initial page");
         }
         return null;
     }
+
+    private static LoadTokenController createLoadTokenUseCase(
+            ViewManagerModel viewManagerModel, GetPlaylistViewModel getPlaylistViewModel,
+            ProcessPlaylistViewModel processPlaylistViewModel, PutPlaylistViewModel putPlaylistViewModel,
+            YoutubeAPIAdapterInterface youtubeAPI, SpotifyAPIAdapterInterface spotifyAPI) throws IOException {
+
+        LoadTokenOutputBoundary loadTokenOutputBoundary = new LoadTokenPresenter(viewManagerModel, getPlaylistViewModel, processPlaylistViewModel, putPlaylistViewModel);
+        LoadTokenDataAccessInterface loadTokenDataAccessObject = new LoadTokenDataAccessObject();
+        LoadTokenInputBoundary loadTokenInteractor = new LoadTokenInteractor(loadTokenDataAccessObject, loadTokenOutputBoundary, youtubeAPI, spotifyAPI);
+
+        return new LoadTokenController(loadTokenInteractor);
+    }
+
 
     private static LoadPlaylistController createLoadPlaylistUseCase(
             ViewManagerModel viewManagerModel, GetPlaylistViewModel getPlaylistViewModel,
@@ -65,11 +81,9 @@ public class GetPlaylistUseCaseFactory {
 
     private static YoutubeGetController createYoutubeGetUseCase(
             ViewManagerModel viewManagerModel, GetPlaylistViewModel getPlaylistViewModel,
-            ProcessPlaylistViewModel processPlaylistViewModel, TempFileWriterDataAccessObject fileWriter) throws IOException {
+            ProcessPlaylistViewModel processPlaylistViewModel, TempFileWriterDataAccessObject fileWriter, YoutubeAPIAdapterInterface api) throws IOException {
 
         YoutubeGetOutputBoundary youtubeGetOutputBoundary = new YoutubeGetPresenter(viewManagerModel, getPlaylistViewModel, processPlaylistViewModel);
-
-        YoutubeAPIAdapterInterface api = new YoutubeAPIAdapter();
         YoutubeGetDataAccessInterface youtubeGetDataAccessObject = new YoutubeGetDataAccessObject(api);
 
         YoutubeGetInputBoundary youtubeGetInteractor = new YoutubeGetInteractor(youtubeGetDataAccessObject,
@@ -80,9 +94,8 @@ public class GetPlaylistUseCaseFactory {
 
     private static SpotifyGetController createSpotifyGetUseCase (
             ViewManagerModel viewManagerModel, GetPlaylistViewModel getPlaylistViewModel,
-            ProcessPlaylistViewModel processPlaylistViewModel, TempFileWriterDataAccessObject fileWriter) throws IOException{
+            ProcessPlaylistViewModel processPlaylistViewModel, TempFileWriterDataAccessObject fileWriter, SpotifyAPIAdapterInterface api) throws IOException{
 
-        SpotifyAPIAdapterInterface api = new SpotifyAPIAdapter();
         SpotifyGetDataAccessInterface spotifyGetDataAccessObject = new SpotifyGetDataAccessObject(api);
         SpotifyGetOutputBoundary spotifyGetOutputBoundary = new SpotifyGetPresenter(viewManagerModel, getPlaylistViewModel, processPlaylistViewModel);
 

--- a/src/app/Main.java
+++ b/src/app/Main.java
@@ -1,5 +1,9 @@
 package app;
 
+import data_access.APIs.SpotifyAPIAdapter;
+import data_access.APIs.SpotifyAPIAdapterInterface;
+import data_access.APIs.YoutubeAPIAdapter;
+import data_access.APIs.YoutubeAPIAdapterInterface;
 import data_access.TempFileWriterDataAccessObject;
 import interface_adapter.GetPlaylistViewModel;
 import interface_adapter.ProcessPlaylistViewModel;
@@ -31,6 +35,10 @@ public class Main {
         JPanel views = new JPanel(cardLayout);
         application.add(views);
 
+        //API objects
+        SpotifyAPIAdapterInterface spotifyAPI = new SpotifyAPIAdapter();
+        YoutubeAPIAdapterInterface youtubeAPI = new YoutubeAPIAdapter();
+
         // This keeps track of and manages which view is currently showing.
         ViewManagerModel viewManagerModel = new ViewManagerModel();
         new ViewManager(views, cardLayout, viewManagerModel);
@@ -45,17 +53,17 @@ public class Main {
         TempFileWriterDataAccessObject backupFileWriter = new TempFileWriterDataAccessObject("backup.json");
 
         // create the views
-        InitialView initialView = GetPlaylistUseCaseFactory.create(
+        InitialView initialView = GetPlaylistUseCaseFactory.create(spotifyAPI, youtubeAPI,
                 viewManagerModel, getPlaylistViewModel, processPlaylistViewModel, putPlaylistViewModel, fileWriter);
         assert initialView != null;
         views.add(initialView, initialView.viewName);  // viewName is "page 1"
 
-        OutputPageView outputPageView = PutPlaylistUseCaseFactory.create(
+        OutputPageView outputPageView = PutPlaylistUseCaseFactory.create(spotifyAPI, youtubeAPI,
                 viewManagerModel, putPlaylistViewModel, processPlaylistViewModel, getPlaylistViewModel, fileWriter);
         assert outputPageView != null;
         views.add(outputPageView, outputPageView.viewName);
 
-        MatchOrSplitSelectionView matchOrSplitSelectionView = ProcessPlaylistUseCaseFactory.create(
+        MatchOrSplitSelectionView matchOrSplitSelectionView = ProcessPlaylistUseCaseFactory.create(spotifyAPI, youtubeAPI,
                 viewManagerModel, processPlaylistViewModel, putPlaylistViewModel, fileWriter, backupFileWriter,
                 outputPageView.getSavePlaylistController(), outputPageView.getViewTraverseController());
         assert matchOrSplitSelectionView != null;

--- a/src/app/ProcessPlaylistUseCaseFactory.java
+++ b/src/app/ProcessPlaylistUseCaseFactory.java
@@ -31,13 +31,14 @@ public class ProcessPlaylistUseCaseFactory {
 
     private ProcessPlaylistUseCaseFactory() {}
 
-    public static MatchOrSplitSelectionView create(ViewManagerModel viewManagerModel,
+    public static MatchOrSplitSelectionView create(SpotifyAPIAdapterInterface spotifyAPI, YoutubeAPIAdapterInterface youtubeAPI,
+                                                   ViewManagerModel viewManagerModel,
                                                    ProcessPlaylistViewModel processPlaylistViewModel, PutPlaylistViewModel putPlaylistViewModel,
                                                    TempFileWriterDataAccessObject fileWriter, TempFileWriterDataAccessObject backupFileWriter,
                                                    SavePlaylistController savePlaylistController, ViewTraverseController viewTraverseController) {
         try {
-            YoutubeMatchController youtubeMatchController = createYoutubeMatchUseCase(viewManagerModel, processPlaylistViewModel, putPlaylistViewModel, fileWriter, backupFileWriter);
-            SpotifyMatchController spotifyMatchController = createSpotifyMatchUseCase(viewManagerModel, processPlaylistViewModel, putPlaylistViewModel, fileWriter, backupFileWriter);
+            YoutubeMatchController youtubeMatchController = createYoutubeMatchUseCase(viewManagerModel, processPlaylistViewModel, putPlaylistViewModel, fileWriter, backupFileWriter, spotifyAPI);
+            SpotifyMatchController spotifyMatchController = createSpotifyMatchUseCase(viewManagerModel, processPlaylistViewModel, putPlaylistViewModel, fileWriter, backupFileWriter, youtubeAPI);
             return new MatchOrSplitSelectionView(processPlaylistViewModel, youtubeMatchController, spotifyMatchController, savePlaylistController, viewTraverseController);
         } catch (IOException e) {
             JOptionPane.showMessageDialog(null, "could not load initial page");
@@ -48,11 +49,9 @@ public class ProcessPlaylistUseCaseFactory {
     private static YoutubeMatchController createYoutubeMatchUseCase(
             ViewManagerModel viewManagerModel, ProcessPlaylistViewModel processPlaylistViewModel,
             PutPlaylistViewModel putPlaylistViewModel, TempFileWriterDataAccessObject fileWriter,
-            TempFileWriterDataAccessObject backupFileWriter) throws IOException {
+            TempFileWriterDataAccessObject backupFileWriter, SpotifyAPIAdapterInterface api) throws IOException {
 
         YoutubeMatchOutputBoundary presenter = new YoutubeMatchPresenter(viewManagerModel, processPlaylistViewModel, putPlaylistViewModel);
-
-        SpotifyAPIAdapterInterface api = new SpotifyAPIAdapter();
         YoutubeMatchDataAccessInterface dataAccessObject = new YoutubeMatchDataAccessObject(api);
 
         YoutubeMatchInputBoundary interactor = new YoutubeMatchInteractor(dataAccessObject, fileWriter, backupFileWriter, presenter);
@@ -63,19 +62,14 @@ public class ProcessPlaylistUseCaseFactory {
     private static SpotifyMatchController createSpotifyMatchUseCase(
             ViewManagerModel viewManagerModel, ProcessPlaylistViewModel processPlaylistViewModel,
             PutPlaylistViewModel putPlaylistViewModel, TempFileWriterDataAccessObject fileWriter,
-            TempFileWriterDataAccessObject backupFileWriter) throws IOException {
+            TempFileWriterDataAccessObject backupFileWriter, YoutubeAPIAdapterInterface api) throws IOException {
 
         SpotifyMatchOutputBoundary presenter = new SpotifyMatchPresenter(viewManagerModel, processPlaylistViewModel, putPlaylistViewModel);
-
-        YoutubeAPIAdapterInterface api = new YoutubeAPIAdapter();
         SpotifyMatchDataAccessInterface dataAccessObject = new SpotifyMatchDataAccessObject(api);
 
         SpotifyMatchInputBoundary interactor = new SpotifyMatchInteractor(dataAccessObject, fileWriter, backupFileWriter, presenter);
 
         return new SpotifyMatchController(interactor);
     }
-
-
-
 
 }

--- a/src/app/PutPlaylistUseCaseFactory.java
+++ b/src/app/PutPlaylistUseCaseFactory.java
@@ -45,7 +45,8 @@ public class PutPlaylistUseCaseFactory {
 
     private PutPlaylistUseCaseFactory() {}
 
-    public static OutputPageView create(ViewManagerModel viewManagerModel,
+    public static OutputPageView create(SpotifyAPIAdapterInterface spotifyAPI, YoutubeAPIAdapterInterface youtubeAPI,
+                                        ViewManagerModel viewManagerModel,
                                         PutPlaylistViewModel putPlaylistViewModel,
                                         ProcessPlaylistViewModel processPlaylistViewModel,
                                         GetPlaylistViewModel getPlaylistViewModel,
@@ -53,8 +54,8 @@ public class PutPlaylistUseCaseFactory {
         try {
             SavePlaylistController savePlaylistController = createSavePlaylistUseCase(viewManagerModel, putPlaylistViewModel, fileWriter);
             ViewTraverseController viewTraverseController = createViewTraverseUseCase(viewManagerModel, getPlaylistViewModel, processPlaylistViewModel, putPlaylistViewModel);
-            YoutubePutController youtubePutController = createYoutubePutUseCase(viewManagerModel, putPlaylistViewModel);
-            SpotifyPutController spotifyPutController = createSpotifyPutUseCase(viewManagerModel, putPlaylistViewModel);
+            YoutubePutController youtubePutController = createYoutubePutUseCase(viewManagerModel, putPlaylistViewModel, spotifyAPI);
+            SpotifyPutController spotifyPutController = createSpotifyPutUseCase(viewManagerModel, putPlaylistViewModel, youtubeAPI);
             ViewPlaylistController viewPlaylistController = createViewPlaylistUseCase(putPlaylistViewModel);
             return new OutputPageView(putPlaylistViewModel, getPlaylistViewModel, savePlaylistController, viewTraverseController, youtubePutController, spotifyPutController, viewPlaylistController);
         } catch (IOException e) {
@@ -84,8 +85,7 @@ public class PutPlaylistUseCaseFactory {
         return new ViewTraverseController(viewTraverseInteractor);
     }
 
-    public static YoutubePutController createYoutubePutUseCase(ViewManagerModel viewManagerModel, PutPlaylistViewModel putPlaylistViewModel) {
-        SpotifyAPIAdapterInterface api = new SpotifyAPIAdapter();
+    public static YoutubePutController createYoutubePutUseCase(ViewManagerModel viewManagerModel, PutPlaylistViewModel putPlaylistViewModel, SpotifyAPIAdapterInterface api) {
 
         YoutubePutDataAccessInterface youtubePutDataAccessObject = new YoutubePutDataAccessObject(api);
         YoutubePutOutputBoundary youtubePutPresenter = new YoutubePutPresenter(viewManagerModel, putPlaylistViewModel);
@@ -95,9 +95,7 @@ public class PutPlaylistUseCaseFactory {
         return new YoutubePutController(youtubePutInteractor);
     }
 
-    public static SpotifyPutController createSpotifyPutUseCase(ViewManagerModel viewManagerModel, PutPlaylistViewModel putPlaylistViewModel) {
-        YoutubeAPIAdapterInterface api = new YoutubeAPIAdapter();
-
+    public static SpotifyPutController createSpotifyPutUseCase(ViewManagerModel viewManagerModel, PutPlaylistViewModel putPlaylistViewModel, YoutubeAPIAdapterInterface api) {
         SpotifyPutDataAccessInterface spotifyPutDataAccessObject = new SpotifyPutDataAccessObject(api);
         SpotifyPutOutputBoundary spotifyPutPresenter = new SpotifyPutPresenter(viewManagerModel, putPlaylistViewModel);
 

--- a/src/data_access/APIs/SpotifyAPIAdapter.java
+++ b/src/data_access/APIs/SpotifyAPIAdapter.java
@@ -21,6 +21,12 @@ public class SpotifyAPIAdapter extends APIcaller implements SpotifyAPIAdapterInt
     }
 
     @Override
+    public void setTokens(String clientID, String clientSecret) {
+        this.clientID = clientID;
+        this.clientSecret = clientSecret;
+    }
+
+    @Override
     public String getPlaylist(String playlistID) {
         String apiCall = apiMainUrl + "playlists/" + playlistID;
         APIRequestInfo info = new APIRequestInfo(apiCall, "GET", null, null);

--- a/src/data_access/APIs/SpotifyAPIAdapterInterface.java
+++ b/src/data_access/APIs/SpotifyAPIAdapterInterface.java
@@ -3,6 +3,7 @@ package data_access.APIs;
 import org.json.JSONArray;
 
 public interface SpotifyAPIAdapterInterface {
+    void setTokens(String clientID, String clientSecret);
     String request(APIRequestInfo info);
     String getPlaylist(String playlistID);
     String searchSong(String query);

--- a/src/data_access/APIs/YoutubeAPIAdapter.java
+++ b/src/data_access/APIs/YoutubeAPIAdapter.java
@@ -10,7 +10,7 @@ import java.net.URL;
 import java.util.Objects;
 
 public class YoutubeAPIAdapter extends APIcaller implements YoutubeAPIAdapterInterface {
-    private final String apiKey;
+    private String apiKey;
 
     public YoutubeAPIAdapter() {
         this.apiKey = "AIzaSyDBBye718R0GFZp0Q09jmisniArShBFInI";
@@ -20,6 +20,13 @@ public class YoutubeAPIAdapter extends APIcaller implements YoutubeAPIAdapterInt
         this.scope = "https://www.googleapis.com/auth/youtube";
         this.authCodeUrl = "https://accounts.google.com/o/oauth2/v2/auth?";
         this.authTokenExchange = "https://oauth2.googleapis.com/token";
+    }
+
+    @Override
+    public void setTokens(String clientID, String clientSecret, String apiKey) {
+        this.clientID = clientID;
+        this.clientSecret = clientSecret;
+        this.apiKey = apiKey;
     }
 
     @Override

--- a/src/data_access/APIs/YoutubeAPIAdapterInterface.java
+++ b/src/data_access/APIs/YoutubeAPIAdapterInterface.java
@@ -1,6 +1,7 @@
 package data_access.APIs;
 
 public interface YoutubeAPIAdapterInterface {
+    void setTokens(String clientID, String clientSecret, String apiKey);
     String request(APIRequestInfo info);
     String getPlaylist(String playlistID, String pageToken);
     String searchSong(String query);

--- a/src/data_access/LoadTokenDataAccessObject.java
+++ b/src/data_access/LoadTokenDataAccessObject.java
@@ -1,0 +1,95 @@
+package data_access;
+
+import data_access.APIs.SpotifyAPIAdapterInterface;
+import data_access.APIs.YoutubeAPIAdapterInterface;
+import entity.*;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import use_case.load_token.LoadTokenDataAccessInterface;
+import view.InitialView;
+
+import javax.swing.*;
+import javax.swing.filechooser.FileNameExtensionFilter;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Objects;
+import java.util.prefs.Preferences;
+
+import static data_access.TempFileWriterDataAccessObject.readTempJSON;
+
+public class LoadTokenDataAccessObject implements LoadTokenDataAccessInterface {
+    private String filepath;
+
+    public void setFilePath(String filepath) {
+        this.filepath = filepath;
+    }
+    public String fetchFilePath() {
+        return this.filepath;
+    }
+
+    public String getFilePath() {
+        JFileChooser fileChooser = new JFileChooser("src");
+        Preferences prefs = Preferences.userNodeForPackage(InitialView.class);
+        String lastOpenedFilePath = prefs.get("lastOpenedFilePath", null);
+
+        // Set the initially selected file to the parent folder of the most recently opened file
+        if (lastOpenedFilePath != null) {
+            File lastOpenedFile = new File(lastOpenedFilePath);
+            if (lastOpenedFile.exists() && lastOpenedFile.isFile()) {
+                fileChooser.setSelectedFile(lastOpenedFile.getAbsoluteFile());
+            }
+        }
+
+        //sets a filter for possible extensions
+        FileNameExtensionFilter filter1 = new FileNameExtensionFilter("SongWarp API token sheet", "SWtokens");
+        FileNameExtensionFilter filter2 = new FileNameExtensionFilter("Text Files", "txt");
+        fileChooser.setFileFilter(filter1);
+        fileChooser.addChoosableFileFilter(filter2);
+
+        int result = fileChooser.showOpenDialog(null);
+
+        if (result == JFileChooser.APPROVE_OPTION) {
+            File selectedFile = fileChooser.getSelectedFile();
+            prefs.put("lastOpenedFilePath", selectedFile.getAbsolutePath());
+
+            // Get the absolute path of the selected file and set it in the text field
+            return selectedFile.getAbsolutePath();
+        }
+        return null;
+    }
+
+    public JSONObject readTokenSave(String file) {
+
+        try (BufferedReader br = new BufferedReader(new FileReader(file))) {
+            JSONObject jsonObject = new JSONObject();
+            String line;
+            String[] keyThings = {"youtubeKey", "youtubeClientID", "youtubeClientSecret", "spotifyClientID", "spotifyClientSecret"};
+            int i = 0;
+            while ((line = br.readLine()) != null) {
+                jsonObject.put(keyThings[i], line.trim());
+                i++;
+            }
+            return jsonObject;
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    @Override
+    public void updateAPIAdapters(JSONObject tokenObject, YoutubeAPIAdapterInterface youtubeAPI, SpotifyAPIAdapterInterface spotifyAPI) {
+        String yKey = tokenObject.getString("youtubeKey");
+        String yID = tokenObject.getString("youtubeClientID");
+        String ySecret = tokenObject.getString("youtubeClientSecret");
+        String sID = tokenObject.getString("spotifyClientID");
+        String sSecret = tokenObject.getString("spotifyClientSecret");
+
+        youtubeAPI.setTokens(yID, ySecret, yKey);
+        spotifyAPI.setTokens(sID, sSecret);
+    }
+}

--- a/src/data_access/SaveTokenDataAccessObject.java
+++ b/src/data_access/SaveTokenDataAccessObject.java
@@ -1,0 +1,60 @@
+package data_access;
+
+import data_access.APIs.SpotifyAPIAdapterInterface;
+import data_access.APIs.YoutubeAPIAdapterInterface;
+import org.json.JSONObject;
+import use_case.save_token.SaveTokenDataAccessInterface;
+import use_case.save_token.SaveTokenInputData;
+
+import javax.swing.*;
+import javax.swing.filechooser.FileSystemView;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+
+public class SaveTokenDataAccessObject implements SaveTokenDataAccessInterface {
+    @Override
+    public String saveTokenSheet(SaveTokenInputData inputData) {
+        JFileChooser fileChooser = new JFileChooser(FileSystemView.getFileSystemView().getHomeDirectory());
+        fileChooser.setDialogTitle("Select Folder to Save");
+        fileChooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
+        int returnValue = fileChooser.showDialog(null, "Save");
+
+        if (returnValue == JFileChooser.APPROVE_OPTION) {
+            String selectedDirectory = fileChooser.getSelectedFile().getAbsolutePath();
+            String time = LocalTime.now().format(DateTimeFormatter.ofPattern("HH-mm-ss", Locale.ENGLISH));
+            String fileName = "API_token_sheet_" + time;
+            String filePath = selectedDirectory + File.separator + fileName + ".SWtokens";
+            JSONObject jsonObject = inputData.getData();
+
+            try (FileWriter file = new FileWriter(filePath)) {
+                for (String key : jsonObject.keySet()) {
+                    file.write(jsonObject.getString(key) + "\n");
+                }
+                System.out.println("Token Sheet saved to " + filePath);
+                return filePath;
+
+            } catch (IOException e) {
+                return null;
+            }
+        } else if (returnValue == JFileChooser.CANCEL_OPTION) {
+            System.out.println("User canceled the operation");
+        }
+        return null;
+    }
+
+    @Override
+    public void updateAPIAdapters(JSONObject tokenObject, YoutubeAPIAdapterInterface youtubeAPI, SpotifyAPIAdapterInterface spotifyAPI) {
+        String yKey = tokenObject.getString("youtubeKey");
+        String yID = tokenObject.getString("youtubeClientID");
+        String ySecret = tokenObject.getString("youtubeClientSecret");
+        String sID = tokenObject.getString("spotifyClientID");
+        String sSecret = tokenObject.getString("spotifyClientSecret");
+
+        youtubeAPI.setTokens(yID, ySecret, yKey);
+        spotifyAPI.setTokens(sID, sSecret);
+    }
+}

--- a/src/interface_adapter/GetPlaylistViewModel.java
+++ b/src/interface_adapter/GetPlaylistViewModel.java
@@ -4,7 +4,7 @@ import java.beans.PropertyChangeSupport;
 
 public class GetPlaylistViewModel extends ViewModel {
     public final String LOADTOKEN_BUTTON_LABEL = "Load your own API key sheet";
-    public final String TOKENSAVE_BUTTON_LABEL = "Save a API key sheet";
+    public final String TOKENSAVE_BUTTON_LABEL = "Create an API key sheet";
     public final String TITLE_LABEL = "Start page";
     public final String URL_LABEL = "Enter playlist url";
     public final String YOUTUBEGET_BUTTON_LABEL = "From Youtube Url";

--- a/src/interface_adapter/GetPlaylistViewModel.java
+++ b/src/interface_adapter/GetPlaylistViewModel.java
@@ -3,6 +3,8 @@ import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
 
 public class GetPlaylistViewModel extends ViewModel {
+    public final String LOADTOKEN_BUTTON_LABEL = "Load your own API key sheet";
+    public final String TOKENSAVE_BUTTON_LABEL = "Save a API key sheet";
     public final String TITLE_LABEL = "Start page";
     public final String URL_LABEL = "Enter playlist url";
     public final String YOUTUBEGET_BUTTON_LABEL = "From Youtube Url";

--- a/src/interface_adapter/load_token/LoadTokenController.java
+++ b/src/interface_adapter/load_token/LoadTokenController.java
@@ -1,0 +1,15 @@
+package interface_adapter.load_token;
+
+import use_case.load_token.LoadTokenInputBoundary;
+
+public class LoadTokenController {
+    final LoadTokenInputBoundary loadTokenUseCaseInteractor;
+
+    public LoadTokenController(LoadTokenInputBoundary loadTokenUseCaseInteractor) {
+        this.loadTokenUseCaseInteractor = loadTokenUseCaseInteractor;
+    }
+
+    public void execute() {
+        loadTokenUseCaseInteractor.execute();
+    }
+}

--- a/src/interface_adapter/load_token/LoadTokenPresenter.java
+++ b/src/interface_adapter/load_token/LoadTokenPresenter.java
@@ -1,0 +1,34 @@
+package interface_adapter.load_token;
+
+import interface_adapter.*;
+import use_case.load_playlist.LoadPlaylistOutputData;
+import use_case.load_token.LoadTokenOutputBoundary;
+import use_case.load_token.LoadTokenOutputData;
+
+public class LoadTokenPresenter implements LoadTokenOutputBoundary {
+    private final ViewManagerModel viewManagerModel;
+    private final GetPlaylistViewModel getPlaylistViewModel;
+    private final ProcessPlaylistViewModel processPlaylistViewModel;
+    private final PutPlaylistViewModel putPlaylistViewModel;
+
+    public LoadTokenPresenter(ViewManagerModel viewManagerModel, GetPlaylistViewModel getPlaylistViewModel,
+                              ProcessPlaylistViewModel processPlaylistViewModel, PutPlaylistViewModel putPlaylistViewModel) {
+        this.viewManagerModel = viewManagerModel;
+        this.getPlaylistViewModel = getPlaylistViewModel;
+        this.processPlaylistViewModel = processPlaylistViewModel;
+        this.putPlaylistViewModel = putPlaylistViewModel;
+    }
+    @Override
+    public void prepareSuccessView(LoadTokenOutputData data) {
+        GetPlaylistState state = getPlaylistViewModel.getState();
+        state.setError(data.toString());
+        getPlaylistViewModel.firePropertyChanged();
+    }
+
+    @Override
+    public void prepareFailView(String error) {
+        GetPlaylistState state = getPlaylistViewModel.getState();
+        state.setError(error);
+        getPlaylistViewModel.firePropertyChanged();
+    }
+}

--- a/src/interface_adapter/save_token/SaveTokenController.java
+++ b/src/interface_adapter/save_token/SaveTokenController.java
@@ -1,0 +1,30 @@
+package interface_adapter.save_token;
+
+import entity.Playlist;
+import use_case.save_playlist.SavePlaylistInputBoundary;
+import use_case.save_playlist.SavePlaylistInputData;
+import use_case.save_token.SaveTokenInputBoundary;
+import use_case.save_token.SaveTokenInputData;
+
+import javax.swing.*;
+
+
+public class SaveTokenController {
+    private final SaveTokenInputBoundary interactor;
+
+    public SaveTokenController(SaveTokenInputBoundary interactor) {
+        this.interactor = interactor;
+    }
+
+    public void execute(JTextField[] info) {
+        try {
+            SaveTokenInputData inputData = new SaveTokenInputData(info);
+
+            interactor.execute(inputData);
+        } catch (Exception e) {
+            // Handle exceptions as needed
+            e.printStackTrace();
+        }
+    }
+
+}

--- a/src/interface_adapter/save_token/SaveTokenPresenter.java
+++ b/src/interface_adapter/save_token/SaveTokenPresenter.java
@@ -1,0 +1,35 @@
+package interface_adapter.save_token;
+
+import interface_adapter.GetPlaylistState;
+import interface_adapter.GetPlaylistViewModel;
+import interface_adapter.PutPlaylistViewModel;
+import interface_adapter.ViewManagerModel;
+import use_case.save_playlist.SavePlaylistOutputBoundary;
+import use_case.save_playlist.SavePlaylistOutputData;
+import use_case.save_token.SaveTokenOutputBoundary;
+import use_case.save_token.SaveTokenOutputData;
+
+
+public class SaveTokenPresenter implements SaveTokenOutputBoundary {
+    private final GetPlaylistViewModel getPlaylistViewModel;
+    private final ViewManagerModel viewManagerModel;
+
+    public SaveTokenPresenter(ViewManagerModel viewManagerModel, GetPlaylistViewModel getPlaylistViewModel) {
+        this.getPlaylistViewModel = getPlaylistViewModel;
+        this.viewManagerModel = viewManagerModel;
+    }
+
+    @Override
+    public void prepareSuccessView(SaveTokenOutputData outputData) {
+        GetPlaylistState state = getPlaylistViewModel.getState();
+        state.setError("Successfully saved API token sheet\nand updated API keys (no need to load the file now)");
+        getPlaylistViewModel.firePropertyChanged();
+    }
+
+    @Override
+    public void prepareFailView(String error) {
+        GetPlaylistState state = getPlaylistViewModel.getState();
+        state.setError(error);
+        getPlaylistViewModel.firePropertyChanged();
+    }
+}

--- a/src/test/TestViews.java
+++ b/src/test/TestViews.java
@@ -1,6 +1,10 @@
 import app.GetPlaylistUseCaseFactory;
 import app.ProcessPlaylistUseCaseFactory;
 import app.PutPlaylistUseCaseFactory;
+import data_access.APIs.SpotifyAPIAdapter;
+import data_access.APIs.SpotifyAPIAdapterInterface;
+import data_access.APIs.YoutubeAPIAdapter;
+import data_access.APIs.YoutubeAPIAdapterInterface;
 import data_access.TempFileWriterDataAccessObject;
 import interface_adapter.GetPlaylistViewModel;
 import interface_adapter.ProcessPlaylistViewModel;
@@ -32,6 +36,9 @@ public class TestViews {
         JPanel views = new JPanel(cardLayout);
         application.add(views);
 
+        SpotifyAPIAdapterInterface spotifyAPI = new SpotifyAPIAdapter();
+        YoutubeAPIAdapterInterface youtubeAPI = new YoutubeAPIAdapter();
+
         ViewManagerModel viewManagerModel = new ViewManagerModel();
         new ViewManager(views, cardLayout, viewManagerModel);
 
@@ -45,17 +52,17 @@ public class TestViews {
         TempFileWriterDataAccessObject backupFileWriter = new TempFileWriterDataAccessObject("backup.json");
 
         // create the views
-        InitialView initialView = GetPlaylistUseCaseFactory.create(
+        InitialView initialView = GetPlaylistUseCaseFactory.create(spotifyAPI, youtubeAPI,
                 viewManagerModel, getPlaylistViewModel, processPlaylistViewModel, putPlaylistViewModel, fileWriter);
         assert initialView != null;
         views.add(initialView, initialView.viewName);  // viewName is "page 1"
 
-        OutputPageView outputPageView = PutPlaylistUseCaseFactory.create(
+        OutputPageView outputPageView = PutPlaylistUseCaseFactory.create(spotifyAPI, youtubeAPI,
                 viewManagerModel, putPlaylistViewModel, processPlaylistViewModel, getPlaylistViewModel, fileWriter);
         assert outputPageView != null;
         views.add(outputPageView, outputPageView.viewName);
 
-        MatchOrSplitSelectionView matchOrSplitSelectionView = ProcessPlaylistUseCaseFactory.create(
+        MatchOrSplitSelectionView matchOrSplitSelectionView = ProcessPlaylistUseCaseFactory.create(spotifyAPI, youtubeAPI,
                 viewManagerModel, processPlaylistViewModel, putPlaylistViewModel, fileWriter, backupFileWriter,
                 outputPageView.getSavePlaylistController(), outputPageView.getViewTraverseController());
         assert matchOrSplitSelectionView != null;

--- a/src/use_case/load_token/LoadTokenDataAccessInterface.java
+++ b/src/use_case/load_token/LoadTokenDataAccessInterface.java
@@ -1,0 +1,20 @@
+package use_case.load_token;
+
+import data_access.APIs.SpotifyAPIAdapter;
+import data_access.APIs.SpotifyAPIAdapterInterface;
+import data_access.APIs.YoutubeAPIAdapterInterface;
+import entity.CompletePlaylist;
+import entity.SpotifyPlaylist;
+import entity.YoutubePlaylist;
+import org.json.JSONObject;
+
+public interface LoadTokenDataAccessInterface {
+
+    void setFilePath(String filePath);
+    String fetchFilePath();
+    String getFilePath();
+    JSONObject readTokenSave(String file);
+
+    void updateAPIAdapters(JSONObject tokenObject, YoutubeAPIAdapterInterface youtubeAPI,
+                           SpotifyAPIAdapterInterface spotifyAPI);
+}

--- a/src/use_case/load_token/LoadTokenInputBoundary.java
+++ b/src/use_case/load_token/LoadTokenInputBoundary.java
@@ -1,0 +1,6 @@
+package use_case.load_token;
+
+public interface LoadTokenInputBoundary {
+
+    void execute();
+}

--- a/src/use_case/load_token/LoadTokenInputData.java
+++ b/src/use_case/load_token/LoadTokenInputData.java
@@ -1,0 +1,13 @@
+package use_case.load_token;
+
+public class LoadTokenInputData {
+    private final String filePath;
+
+    public LoadTokenInputData(String filePath) {
+        this.filePath = filePath;
+    }
+
+    public String getFilePath() {
+        return filePath;
+    }
+}

--- a/src/use_case/load_token/LoadTokenInteractor.java
+++ b/src/use_case/load_token/LoadTokenInteractor.java
@@ -1,0 +1,42 @@
+package use_case.load_token;
+
+import data_access.APIs.SpotifyAPIAdapterInterface;
+import data_access.APIs.YoutubeAPIAdapterInterface;
+import entity.CompletePlaylist;
+import entity.SpotifyPlaylist;
+import entity.YoutubePlaylist;
+import org.json.JSONObject;
+import utilities.CheckMultiplePlaylist;
+import utilities.SplitFile;
+
+import java.util.Objects;
+
+public class LoadTokenInteractor implements LoadTokenInputBoundary {
+    private final LoadTokenDataAccessInterface loadTokenDataAccessObject;
+    private final LoadTokenOutputBoundary loadTokenPresenter;
+    private final YoutubeAPIAdapterInterface youtubeAPI;
+    private final SpotifyAPIAdapterInterface spotifyAPI;
+
+    public LoadTokenInteractor(LoadTokenDataAccessInterface loadTokenDataAccessObject,
+                               LoadTokenOutputBoundary loadTokenPresenter,
+                               YoutubeAPIAdapterInterface youtubeAPI, SpotifyAPIAdapterInterface spotifyAPI) {
+        this.loadTokenDataAccessObject = loadTokenDataAccessObject;
+        this.loadTokenPresenter = loadTokenPresenter;
+        this.youtubeAPI = youtubeAPI;
+        this.spotifyAPI = spotifyAPI;
+    }
+
+    @Override
+    public void execute() {
+        try {
+            String filepath = loadTokenDataAccessObject.getFilePath();
+            JSONObject tokenObject = loadTokenDataAccessObject.readTokenSave(filepath);
+            loadTokenDataAccessObject.updateAPIAdapters(tokenObject, youtubeAPI, spotifyAPI);
+            LoadTokenOutputData loadTokenOutputData = new LoadTokenOutputData(tokenObject);
+            loadTokenPresenter.prepareSuccessView(loadTokenOutputData);
+
+        } catch (Exception e) {
+            loadTokenPresenter.prepareFailView("Failed to load tokenSheet");
+        }
+    }
+}

--- a/src/use_case/load_token/LoadTokenOutputBoundary.java
+++ b/src/use_case/load_token/LoadTokenOutputBoundary.java
@@ -1,0 +1,7 @@
+package use_case.load_token;
+
+public interface LoadTokenOutputBoundary {
+    void prepareSuccessView(LoadTokenOutputData outputData);
+
+    void prepareFailView(String error);
+}

--- a/src/use_case/load_token/LoadTokenOutputData.java
+++ b/src/use_case/load_token/LoadTokenOutputData.java
@@ -1,0 +1,22 @@
+package use_case.load_token;
+
+import org.json.JSONObject;
+
+public class LoadTokenOutputData {
+    private JSONObject data;
+
+    public LoadTokenOutputData(JSONObject tokenObject) {
+        this.data = tokenObject;
+    }
+
+    public String toString() {
+        StringBuilder toPrint = new StringBuilder();
+        for (String key : data.keySet()) {
+            String value = (String) data.get(key);
+            if (value != null) {
+                toPrint.append(key).append(": ").append(value).append("\n");
+            }
+        }
+        return toPrint.toString();
+    }
+}

--- a/src/use_case/save_token/SaveTokenDataAccessInterface.java
+++ b/src/use_case/save_token/SaveTokenDataAccessInterface.java
@@ -1,0 +1,10 @@
+package use_case.save_token;
+
+import data_access.APIs.SpotifyAPIAdapterInterface;
+import data_access.APIs.YoutubeAPIAdapterInterface;
+import org.json.JSONObject;
+
+public interface SaveTokenDataAccessInterface {
+    String saveTokenSheet(SaveTokenInputData inputData);
+    void updateAPIAdapters(JSONObject tokenObject, YoutubeAPIAdapterInterface youtubeAPI, SpotifyAPIAdapterInterface spotifyAPI);
+}

--- a/src/use_case/save_token/SaveTokenInputBoundary.java
+++ b/src/use_case/save_token/SaveTokenInputBoundary.java
@@ -1,0 +1,5 @@
+package use_case.save_token;
+
+public interface SaveTokenInputBoundary {
+    void execute(SaveTokenInputData inputData);
+}

--- a/src/use_case/save_token/SaveTokenInputData.java
+++ b/src/use_case/save_token/SaveTokenInputData.java
@@ -1,0 +1,23 @@
+package use_case.save_token;
+
+import entity.Playlist;
+import org.json.JSONObject;
+
+import javax.swing.*;
+
+public class SaveTokenInputData {
+    private final JSONObject data;
+
+    public SaveTokenInputData(JTextField[] info) {
+        String[] keys = {"youtubeKey", "youtubeClientID", "youtubeClientSecret", "spotifyClientID", "spotifyClientSecret"};
+        JSONObject jsonObject = new JSONObject();
+        for (int i = 0; i < 5; i++) {
+            jsonObject.put(keys[i], info[i].getText());
+        }
+        this.data = jsonObject;
+    }
+
+    public JSONObject getData() {
+        return data;
+    }
+}

--- a/src/use_case/save_token/SaveTokenInteractor.java
+++ b/src/use_case/save_token/SaveTokenInteractor.java
@@ -1,0 +1,33 @@
+package use_case.save_token;
+
+import data_access.APIs.SpotifyAPIAdapterInterface;
+import data_access.APIs.YoutubeAPIAdapterInterface;
+
+public class SaveTokenInteractor implements SaveTokenInputBoundary {
+    private final SaveTokenDataAccessInterface dataAccessObject;
+    private final SaveTokenOutputBoundary presenter;
+    private final YoutubeAPIAdapterInterface youtubeAPI;
+    private final SpotifyAPIAdapterInterface spotifyAPI;
+
+    public SaveTokenInteractor(SaveTokenDataAccessInterface dataAccessObject,
+                               SaveTokenOutputBoundary presenter,
+                               YoutubeAPIAdapterInterface youtubeAPI, SpotifyAPIAdapterInterface spotifyAPI) {
+        this.dataAccessObject = dataAccessObject;
+        this.presenter = presenter;
+        this.youtubeAPI = youtubeAPI;
+        this.spotifyAPI = spotifyAPI;
+    }
+
+    @Override
+    public void execute(SaveTokenInputData inputData) {
+        try {
+            String filepath = dataAccessObject.saveTokenSheet(inputData);
+            dataAccessObject.updateAPIAdapters(inputData.getData(), youtubeAPI, spotifyAPI);
+            SaveTokenOutputData outputData = new SaveTokenOutputData(filepath);
+            presenter.prepareSuccessView(outputData);
+
+        } catch (Exception e) {
+            presenter.prepareFailView("Failed to token sheet: " + e.getMessage());
+        }
+    }
+}

--- a/src/use_case/save_token/SaveTokenOutputBoundary.java
+++ b/src/use_case/save_token/SaveTokenOutputBoundary.java
@@ -1,0 +1,6 @@
+package use_case.save_token;
+
+public interface SaveTokenOutputBoundary {
+    void prepareSuccessView(SaveTokenOutputData outputData);
+    void prepareFailView(String error);
+}

--- a/src/use_case/save_token/SaveTokenOutputData.java
+++ b/src/use_case/save_token/SaveTokenOutputData.java
@@ -1,0 +1,13 @@
+package use_case.save_token;
+
+public class SaveTokenOutputData {
+    private final String filePath;
+
+    public SaveTokenOutputData(String filePath) {
+        this.filePath = filePath;
+    }
+
+    public String getFilePath() {
+        return filePath;
+    }
+}

--- a/src/view/InitialView.java
+++ b/src/view/InitialView.java
@@ -4,6 +4,7 @@ import interface_adapter.GetPlaylistState;
 import interface_adapter.GetPlaylistViewModel;
 
 import interface_adapter.load_playlist.LoadPlaylistController;
+import interface_adapter.load_token.LoadTokenController;
 import interface_adapter.spotify_get.SpotifyGetController;
 import interface_adapter.youtube_get.YoutubeGetController;
 
@@ -24,19 +25,24 @@ public class InitialView extends JPanel implements ActionListener, PropertyChang
     private final YoutubeGetController youtubeGetController;
     private final SpotifyGetController spotifyGetController;
     private final LoadPlaylistController loadPlaylistController;
+    private final LoadTokenController loadTokenController;
     private final JButton youtubeGet;
     private final JButton spotifyGet;
     private final JButton loadPlaylist;
+    private final JButton loadToken;
+    private final JButton saveToken;
 
     public InitialView(GetPlaylistViewModel getPlaylistViewModel,
                        YoutubeGetController youtubeGetController,
                        SpotifyGetController spotifyGetController,
-                       LoadPlaylistController loadPlaylistController
+                       LoadPlaylistController loadPlaylistController,
+                       LoadTokenController loadTokenController
                        ) {
         this.getPlaylistViewModel = getPlaylistViewModel;
         this.youtubeGetController = youtubeGetController;
         this.spotifyGetController = spotifyGetController;
         this.loadPlaylistController = loadPlaylistController;
+        this.loadTokenController = loadTokenController;
 
         getPlaylistViewModel.addPropertyChangeListener(this);
 
@@ -54,6 +60,28 @@ public class InitialView extends JPanel implements ActionListener, PropertyChang
         loadPlaylist = new JButton(getPlaylistViewModel.LOADPLAYLIST_BUTTON_LABEL);
         buttons.add(loadPlaylist);
 
+        JPanel keyStuff = new JPanel();
+        loadToken = new JButton(getPlaylistViewModel.LOADTOKEN_BUTTON_LABEL);
+        keyStuff.add(loadToken);
+        saveToken = new JButton(getPlaylistViewModel.TOKENSAVE_BUTTON_LABEL);
+        keyStuff.add(saveToken);
+
+
+        loadToken.addActionListener(
+                e -> {
+                    if (e.getSource().equals(loadToken)) {
+                        loadTokenController.execute();
+                    }
+                }
+        );
+        saveToken.addActionListener(
+                e -> {
+                    if (e.getSource().equals(saveToken)) {
+
+                    }
+                }
+        );
+
         loadPlaylist.addActionListener(
                 e -> {
                     if (e.getSource().equals(loadPlaylist)) {
@@ -61,7 +89,6 @@ public class InitialView extends JPanel implements ActionListener, PropertyChang
                     }
                 }
         );
-
         youtubeGet.addActionListener(
             new ActionListener() {
                 @Override
@@ -108,6 +135,7 @@ public class InitialView extends JPanel implements ActionListener, PropertyChang
         this.add(title);
         this.add(urlInput);
         this.add(buttons);
+        this.add(keyStuff);
     }
 
     /**

--- a/src/view/InitialView.java
+++ b/src/view/InitialView.java
@@ -5,6 +5,7 @@ import interface_adapter.GetPlaylistViewModel;
 
 import interface_adapter.load_playlist.LoadPlaylistController;
 import interface_adapter.load_token.LoadTokenController;
+import interface_adapter.save_token.SaveTokenController;
 import interface_adapter.spotify_get.SpotifyGetController;
 import interface_adapter.youtube_get.YoutubeGetController;
 
@@ -26,6 +27,7 @@ public class InitialView extends JPanel implements ActionListener, PropertyChang
     private final SpotifyGetController spotifyGetController;
     private final LoadPlaylistController loadPlaylistController;
     private final LoadTokenController loadTokenController;
+    private final SaveTokenController saveTokenController;
     private final JButton youtubeGet;
     private final JButton spotifyGet;
     private final JButton loadPlaylist;
@@ -36,13 +38,15 @@ public class InitialView extends JPanel implements ActionListener, PropertyChang
                        YoutubeGetController youtubeGetController,
                        SpotifyGetController spotifyGetController,
                        LoadPlaylistController loadPlaylistController,
-                       LoadTokenController loadTokenController
+                       LoadTokenController loadTokenController,
+                       SaveTokenController saveTokenController
                        ) {
         this.getPlaylistViewModel = getPlaylistViewModel;
         this.youtubeGetController = youtubeGetController;
         this.spotifyGetController = spotifyGetController;
         this.loadPlaylistController = loadPlaylistController;
         this.loadTokenController = loadTokenController;
+        this.saveTokenController = saveTokenController;
 
         getPlaylistViewModel.addPropertyChangeListener(this);
 
@@ -77,6 +81,26 @@ public class InitialView extends JPanel implements ActionListener, PropertyChang
         saveToken.addActionListener(
                 e -> {
                     if (e.getSource().equals(saveToken)) {
+                        JTextField[] textFields = new JTextField[5];
+                        JPanel panel = new JPanel(new GridLayout(0, 1));
+                        String[] keys = {"youtubeKey", "youtubeClientID", "youtubeClientSecret", "spotifyClientID", "spotifyClientSecret"};
+
+                        for (int i = 0; i < 5; i++) {
+                            textFields[i] = new JTextField(30); // You can adjust the size of the text fields here
+                            panel.add(new JLabel(keys[i]));
+                            panel.add(textFields[i]);
+                        }
+                        int result = JOptionPane.showConfirmDialog(null, panel,
+                                "Enter the appropriate information", JOptionPane.OK_CANCEL_OPTION);
+                        if (result == JOptionPane.OK_OPTION) {
+                            StringBuilder info = new StringBuilder();
+                            for (int i = 0; i < 5; i++) {
+                                info.append(keys[i]).append(": ").append(textFields[i].getText()).append("\n");
+                            }
+                            System.out.println("Entered information:\n" + info.toString());
+
+                            saveTokenController.execute(textFields);
+                        }
 
                     }
                 }

--- a/src/view/OutputPageView.java
+++ b/src/view/OutputPageView.java
@@ -28,7 +28,6 @@ public class OutputPageView extends JPanel implements ActionListener, PropertyCh
     private final SavePlaylistController savePlaylistController;
     private final ViewTraverseController viewTraverseController;
     private final ViewPlaylistController viewPlaylistController;
-
     private final JButton save;
     private final JButton spotifyPut;
     private final JButton youtubePut;


### PR DESCRIPTION
Now you have the ability to enter in your own API info if you want, and save that info as a token sheet, which you can later load in whenever you start the program. 
This way, if you don't want to use the default shared API keys (which may be fully used due to high traffic (unlikely though, since no one is using this lol)), you can rely on your own private ones